### PR TITLE
JsonPointer.parent() Convenience Method

### DIFF
--- a/src/main/java/com/github/fge/jackson/jsonpointer/JsonPointer.java
+++ b/src/main/java/com/github/fge/jackson/jsonpointer/JsonPointer.java
@@ -153,6 +153,24 @@ public final class JsonPointer
     }
 
     /**
+     * Return a new pointer with last token removed; if there
+     * is one or no tokens to remove, the {@link JsonPointer#empty()}
+     * pointer is returned
+     * 
+     * @return a new pointer or {@link JsonPointer#empty()}
+     */
+    public JsonPointer parent()
+    {
+        if (tokenResolvers.size() <= 1)
+            return empty();
+
+        final List<TokenResolver<JsonNode>> list
+            = Lists.newArrayList(tokenResolvers);
+        list.remove(list.size()-1);
+        return new JsonPointer(list);
+    }
+
+    /**
      * Build a list of token resolvers from a list of reference tokens
      *
      * <p>Here, the token resolvers are {@link JsonNodeResolver}s.</p>

--- a/src/main/java/com/github/fge/jackson/jsonpointer/JsonPointer.java
+++ b/src/main/java/com/github/fge/jackson/jsonpointer/JsonPointer.java
@@ -161,13 +161,8 @@ public final class JsonPointer
      */
     public JsonPointer parent()
     {
-        if (tokenResolvers.size() <= 1)
-            return empty();
-
-        final List<TokenResolver<JsonNode>> list
-            = Lists.newArrayList(tokenResolvers);
-        list.remove(list.size()-1);
-        return new JsonPointer(list);
+        final int size = tokenResolvers.size();
+        return size <= 1 ? EMPTY : new JsonPointer(tokenResolvers.subList(0, size - 1));
     }
 
     /**


### PR DESCRIPTION
Francis:

A handy convenience method for JsonPointer if you agree that it is. Otherwise, I was forced to do something like this externally:

```
public static JsonPointer parentJsonPointer(JsonPointer pointer) {
    List<TokenResolver<JsonNode>> parentResolvers = new ArrayList<TokenResolver<JsonNode>>();
    Iterator<TokenResolver<JsonNode>> tokenResolverIter = pointer.iterator();
    if (tokenResolverIter.hasNext()) {
        for (;;) {
            TokenResolver<JsonNode> next = tokenResolverIter.next();
            if (tokenResolverIter.hasNext()) {
                parentResolvers.add(next);
                continue;
            }
            break;
        }
    }
    return new JsonPointer(parentResolvers);
}
```

Seems like something that others may need as well. Thanks!
