### PR TITLE
Enforce OSGI Import-Package of guava libraries to use version >=16 && < 19, to allow using with latest Guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,15 @@ task pom << {
     pom {}.writeTo("${projectDir}/pom.xml");
 }
 
+jar {
+    manifest {
+        instruction 'Import-Package', 'com.google.common.base;version="[16.0,19)",'+
+            'com.google.common.collect;version="[16.0,19)",'+
+            'com.google.common.io;version="[16.0,19)",'+
+             '*';
+    }
+}
+
 /*
  * SIGNING
  */


### PR DESCRIPTION
Using the latest build of the library in an OSGI environment, any apps which uses Guava 18.0 will not be able to use jackson-coreutils (or jackson-patch; see separate pull request), since the Import-Package section of jackson-coreutils specifies com.google.common.base version >=16.0 & < 17.0 (as automatically created by the osgi plugin).

This patch specifically overrides the version requirements for the Guava imports, allowing version >=16  & < 19. This will be a problem when version 19 is released, but the alternative would be to have no upper version at all, which may also cause problems in the future.

Not sure what is best, keep it open and be aware that future versions might deprecate some calls? Guava has a pretty strict deprecation policy (kept 2 years after @Deprecated) so might be quite safe to do.

(And no, I'm probably not the right person to take maintainership, I've just started using json-patch. Thanks for a good library!)
